### PR TITLE
Update finetune_cifar.py

### DIFF
--- a/reproduction/finetune_cifar.py
+++ b/reproduction/finetune_cifar.py
@@ -13,8 +13,7 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch.utils.data.distributed
 
-from scalablebdl.mean_field import PsiSGD
-from scalablebdl.converter import to_bayesian, to_deterministic
+from scalablebdl.mean_field import PsiSGD, to_bayesian, to_deterministic
 from scalablebdl.bnn_utils import freeze, unfreeze, disable_dropout
 
 from utils import AverageMeter, RecorderMeter, time_string, \


### PR DESCRIPTION
Hello, thudzj, 

In Line 17, `ScalableBDL/reproduction/finetune_cifar.py`:
`from scalablebdl.converter import to_bayesian, to_deterministic`

However, I found the two functions, `to_bayesian` and `to_deterministic` are defined in `scalablebdl.mean_field.converter.py` and declared in `scalablebdl.mean_field.__init__.py`. Therefore, following the codes in `ScalableBDL/reproduction/finetune_face.py` and `ScalableBDL/reproduction/finetune_imagenet.py`  I modified it as follows.

`from scalablebdl.mean_field import PsiSGD, to_bayesian, to_deterministic`.

Best

Lan-qing
